### PR TITLE
Responsiveness tweaks

### DIFF
--- a/src/EditDeck/DeckEdit.tsx
+++ b/src/EditDeck/DeckEdit.tsx
@@ -45,7 +45,7 @@ export const DeckEdit: React.FC<DeckEditInterface> = ({deck, updateDeck}) => {
         </Button>)
     return (
         <>
-            <Row className="mb-5 text-start">
+            <Row className="text-start mb-2">
                 <Col sm="2"> Deck ID: {currentDeck.ID} </Col>
                 <Col sm="8">
                     Description:
@@ -65,7 +65,7 @@ export const DeckEdit: React.FC<DeckEditInterface> = ({deck, updateDeck}) => {
                     <Button className="mb-3"
                             onClick={() => addCardToDeck()}
                     >Add FlashCard</Button>
-                    {updated ? commitButton : <Button variant="success" disabled>No Changes to Commit</Button>}
+                    {updated ? commitButton : <Button className="mb-3" variant="success" disabled>No Changes to Commit</Button>}
                 </Col>
             </Row>
             {currentDeck.FlashCards?.map((card, idx, cards) => {

--- a/src/EditDeck/DeckEdit.tsx
+++ b/src/EditDeck/DeckEdit.tsx
@@ -37,7 +37,7 @@ export const DeckEdit: React.FC<DeckEditInterface> = ({deck, updateDeck}) => {
         })
     }
     const commitButton = (
-        <Button variant={"danger"} onClick={event => {
+        <Button className="mb-3" variant={"danger"} onClick={event => {
             updateDeck(currentDeck);
             setUpdated(false);
         }}>

--- a/src/EditDeck/FlashCardEdit.tsx
+++ b/src/EditDeck/FlashCardEdit.tsx
@@ -48,6 +48,13 @@ export const FlashCardEdit: React.FC<FlashCardEditInterface> = ({flashcard, upda
                         }
                     }
                 }
+                const removeAnswerFunc = () => {
+                    flashcard.Answers = allAnswers.filter(value => value.ID !== id);
+                    const newCard = {...flashcard};
+                    updateDeckFunc(newCard);
+
+            }
+
                 return (
                     <span key={id}>
                         <hr/>
@@ -64,6 +71,9 @@ export const FlashCardEdit: React.FC<FlashCardEditInterface> = ({flashcard, upda
                                         updateAnswerFunc(newAnswer);
                                     }
                                 }/>
+                                <Button className="ms-2" variant="danger"
+                                        onClick={() => removeAnswerFunc()}
+                                >Remove Answer</Button>
                             </Col>
                         </Row>
                         <Row className="mb-3">

--- a/src/EditDeck/LoadAndEditDeck.tsx
+++ b/src/EditDeck/LoadAndEditDeck.tsx
@@ -134,12 +134,12 @@ export const LoadAndEditDeck: React.FC = () => {
     return (
         <Container fluid>
             <Row>
-                <Col xs={2} m={6}>
+                <Col xs="auto" m={6}>
                     <Container>
                         {mappedDecks}
                     </Container>
                 </Col>
-                <Col xs={10} md={6}>
+                <Col xs="auto" md="auto">
                     <Container>
                         {selectedDeck && <DeckEdit deck={copyDeck(selectedDeck)} updateDeck={updateDeck}/>}
                     </Container>


### PR DESCRIPTION
Setting the breakpoints to auto seems to prevent text from overflowing on the buttons at smaller screen sizes. The changes to EditDeck.tsx make it so that the "commit changes"/"no changes to commit" button aligns with the "add flashcard" button at smaller sizes.